### PR TITLE
Add support for standardizable SQL tasks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,7 @@ jobs:
                 os: [ubuntu-latest]
                 python-version: ['3.9', '3.10', '3.11', '3.12']
                 airflow-version: ['<2.10', '<2.11']
+                airflow-postgres-version: ['<6']
 
         steps:
             - name: Checkout code
@@ -32,7 +33,7 @@ jobs:
               run: |
                 python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest
-                python -m pip install "apache-airflow${{ matrix.airflow-version }}"
+                python -m pip install "apache-airflow${{ matrix.airflow-version }} apache-airflow-providers-postgres${{ matrix.airflow-postgres-version }}"
             - name: Run the test
               run: pytest
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
               run: |
                 python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest
-                python -m pip install "apache-airflow${{ matrix.airflow-version }} apache-airflow-providers-postgres${{ matrix.airflow-postgres-version }}"
+                python -m pip install "apache-airflow${{ matrix.airflow-version }}" "apache-airflow-providers-postgres${{ matrix.airflow-postgres-version }}"
             - name: Run the test
               run: pytest
 
@@ -60,7 +60,7 @@ jobs:
               run: |
                 python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest pytest-cov coveralls
-                python -m pip install "apache-airflow${{ matrix.airflow-version }}"
+                python -m pip install "apache-airflow${{ matrix.airflow-version }}" "apache-airflow-providers-postgres<6"
             - name: Run the test with coverage
               run: pytest --cov
             - name: Coveralls

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, Astro Data Lab
+Copyright (c) 2024-2025, Astro Data Lab <datalab@noirlab.edu>
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 prune .github
-global-exclude .gitignore .readthedocs.yml
+global-exclude .gitignore .readthedocs.yaml

--- a/dlairflow/postgresql.py
+++ b/dlairflow/postgresql.py
@@ -96,7 +96,7 @@ def pg_restore_schema(connection, schema, dump_dir=None):
                         append_env=True)
 
 
-def q3c_index(connection, schema, table, ra='ra', dec='dec'):
+def q3c_index(connection, schema, table, ra='ra', dec='dec', overwrite=False):
     """Create a q3c index on `schema`.`table`.
 
     Parameters
@@ -111,6 +111,8 @@ def q3c_index(connection, schema, table, ra='ra', dec='dec'):
         Name of the column containing Right Ascension, default 'ra'.
     dec : :class:`str`, optional
         Name of the column containing Declination, default 'dec'.
+    overwrite : :class:`bool`, optional
+        If ``True`` replace any existing SQL template file.
 
     Returns
     -------
@@ -119,7 +121,7 @@ def q3c_index(connection, schema, table, ra='ra', dec='dec'):
     """
     sql_dir = ensure_sql()
     sql_file = os.path.join(sql_dir, "dlairflow.postgresql.q3c_index.sql")
-    if not os.path.exists(sql_file):
+    if overwrite or not os.path.exists(sql_file):
         sql_data = """--
 -- Created by dlairflow.postgresql.q3c_index().
 --

--- a/dlairflow/postgresql.py
+++ b/dlairflow/postgresql.py
@@ -123,8 +123,10 @@ def q3c_index(connection, schema, table, ra='ra', dec='dec'):
         sql_data = """--
 -- Created by dlairflow.postgresql.q3c_index().
 --
-CREATE INDEX {{ params.table }}_q3c_ang2ipix ON {{ params['schema'] }}.{{ params['table'] }} (q3c_ang2ipix("{{ params['ra'] }}", "{{ params['dec'] }}")) WITH (fillfactor=100);
-CLUSTER {{ params.table }}_q3c_ang2ipix ON {{ params['schema'] }}.{{ params['table'] }};
+CREATE INDEX {{ params.table }}_q3c_ang2ipix
+    ON {{ params.schema }}.{{ params.table }} (q3c_ang2ipix("{{ params.ra }}", "{{ params.dec }}"))
+    WITH (fillfactor=100);
+CLUSTER {{ params.table }}_q3c_ang2ipix ON {{ params.schema }}.{{ params.table }};
 """
         with open(sql_file, 'w') as s:
             s.write(sql_data)

--- a/dlairflow/postgresql.py
+++ b/dlairflow/postgresql.py
@@ -120,10 +120,12 @@ def q3c_index(connection, schema, table, ra='ra', dec='dec', overwrite=False):
         A task to create a q3c index
     """
     sql_dir = ensure_sql()
-    sql_file = os.path.join(sql_dir, "dlairflow.postgresql.q3c_index.sql")
+    sql_basename = "dlairflow.postgresql.q3c_index.sql"
+    sql_file = os.path.join(sql_dir, sql_basename)
     if overwrite or not os.path.exists(sql_file):
         sql_data = """--
 -- Created by dlairflow.postgresql.q3c_index().
+-- Call q3c_index(..., overwrite=True) to replace this file.
 --
 CREATE INDEX {{ params.table }}_q3c_ang2ipix
     ON {{ params.schema }}.{{ params.table }} (q3c_ang2ipix("{{ params.ra }}", "{{ params.dec }}"))
@@ -132,8 +134,75 @@ CLUSTER {{ params.table }}_q3c_ang2ipix ON {{ params.schema }}.{{ params.table }
 """
         with open(sql_file, 'w') as s:
             s.write(sql_data)
-    op = PostgresOperator(task_id="q3c_index",
-                          postgres_conn_id=connection,
-                          sql="sql/dlairflow.postgresql.q3c_index.sql",
-                          params={'schema': schema, 'table': table, 'ra': ra, 'dec': dec})
-    return op
+    return PostgresOperator(task_id="q3c_index",
+                            postgres_conn_id=connection,
+                            sql=f"sql/{sql_basename}",
+                            params={'schema': schema, 'table': table, 'ra': ra, 'dec': dec})
+
+
+def index_columns(connection, schema, table, columns, overwrite=False):
+    """Create "generic" indexes for a set of columns
+
+    Parameters
+    ----------
+    connection : :class:`str`
+        An Airflow database connection string.
+    schema : :class:`str`
+        The name of the database schema.
+    table : :class:`str`
+        The name of the table in `schema`.
+    columns : :class:`list`
+        A list of columns to index. See below for the possible entries in
+        the list of columns.
+    overwrite : :class:`bool`, optional
+        If ``True`` replace any existing SQL template file.
+
+    Returns
+    -------
+    :class:`~airflow.providers.postgres.operators.postgres.PostgresOperator`
+        A task to create several indexes.
+
+    Notes
+    -----
+    `columns` may be a list containing multiple types:
+
+    * :class:`str`: create an index on one column.
+    * :class:`tuple`: create an index on the set of columns in the tuple.
+    * :class:`dict`: create a *function* index. The key is the name of the function
+      and the value is the column that is the argument to the function.
+    * Any other type in `columns` will be ignored.
+    """
+    sql_dir = ensure_sql()
+    sql_basename = "dlairflow.postgresql.index_columns.sql"
+    sql_file = os.path.join(sql_dir, sql_basename)
+    if overwrite or not os.path.exists(sql_file):
+        sql_data = """--
+-- Created by dlairflow.postgresql.index_columns().
+-- Call index_columns(..., overwrite=True) to replace this file.
+--
+{% for col in params.columns %}
+{% if col is string -%}
+CREATE INDEX {{ params.table }}_{{ col }}_idx
+    ON {{ params.schema }}.{{ params.table }} ("{{ col }}")
+    WITH (fillfactor=100);
+{% elif col is mapping -%}
+{% for key, value in col.items() -%}
+CREATE_INDEX {{ params.table }}_{{ key|replace('.', '_') }}_{{ value }}_idx
+    ON {{ params.schema }}.{{ params.table }} ({{ key }}({{ value }}))
+    WITH (fillfactor=100);
+{% endfor %}
+{% elif col is sequence -%}
+CREATE INDEX {{ params.table }}_{{ col|join("_") }}_idx
+    ON {{ params.schema }}.{{ params.table }} ("{{ col|join('", "') }}")
+    WITH (fillfactor=100);
+{% else -%}
+-- Unknown type: {{ col }}.
+{% endif -%}
+{% endfor %}
+"""
+        with open(sql_file, 'w') as s:
+            s.write(sql_data)
+    return PostgresOperator(task_id="index_columns",
+                            postgres_conn_id=connection,
+                            sql=f"sql/{sql_basename}",
+                            params={'schema': schema, 'table': table, 'columns': columns})

--- a/dlairflow/test/test_postgresql.py
+++ b/dlairflow/test/test_postgresql.py
@@ -94,7 +94,9 @@ def test_q3c_index(monkeypatch, temporary_airflow_home):
     expected_render = """--
 -- Created by dlairflow.postgresql.q3c_index().
 --
-CREATE INDEX q3c_table_q3c_ang2ipix ON q3c_schema.q3c_table (q3c_ang2ipix("ra", "dec")) WITH (fillfactor=100);
+CREATE INDEX q3c_table_q3c_ang2ipix
+    ON q3c_schema.q3c_table (q3c_ang2ipix("ra", "dec"))
+    WITH (fillfactor=100);
 CLUSTER q3c_table_q3c_ang2ipix ON q3c_schema.q3c_table;
 """
     assert tmpl.render(params=test_operator.params) == expected_render

--- a/dlairflow/test/test_postgresql.py
+++ b/dlairflow/test/test_postgresql.py
@@ -70,8 +70,8 @@ def test_pg_dump_schema(monkeypatch, temporary_airflow_home, task_function, dump
     else:
         assert test_operator.params['dump_dir'] == 'dump_dir'
 
-
-def test_q3c_index(monkeypatch, temporary_airflow_home):
+@pytest.mark.parametrize('overwrite', [(False, ), (True, )])
+def test_q3c_index(monkeypatch, temporary_airflow_home, overwrite):
     """Test the q3c_index function.
     """
     #
@@ -85,7 +85,8 @@ def test_q3c_index(monkeypatch, temporary_airflow_home):
     p = import_module('..postgresql', package='dlairflow.test')
 
     tf = p.__dict__['q3c_index']
-    test_operator = tf("login,password,host,schema", 'q3c_schema', 'q3c_table')
+    test_operator = tf("login,password,host,schema", 'q3c_schema', 'q3c_table',
+                       overwrite=overwrite)
     assert isinstance(test_operator, PostgresOperator)
     assert os.path.exists(str(temporary_airflow_home / 'dags' / 'sql' / 'dlairflow.postgresql.q3c_index.sql'))
     assert test_operator.task_id == 'q3c_index'

--- a/dlairflow/test/test_postgresql.py
+++ b/dlairflow/test/test_postgresql.py
@@ -5,6 +5,7 @@
 import os
 import pytest
 from importlib import import_module
+from jinja2 import Environment, FileSystemLoader
 
 
 class MockConnection(object):
@@ -64,3 +65,36 @@ def test_pg_dump_schema(monkeypatch, temporary_airflow_home, task_function, dump
         assert test_operator.params['dump_dir'] == '/data0/datalab/' + os.environ['USER']
     else:
         assert test_operator.params['dump_dir'] == 'dump_dir'
+
+
+def test_q3c_index(monkeypatch, temporary_airflow_home):
+    """Test the q3c_index function.
+    """
+    def mock_connection(connection):
+        conn = MockConnection(connection)
+        return conn
+    #
+    # Import inside the function to avoid creating $HOME/airflow.
+    #
+    from airflow.hooks.base import BaseHook
+    from airflow.providers.postgres.operators.postgres import PostgresOperator
+
+    monkeypatch.setattr(BaseHook, "get_connection", mock_connection)
+
+    p = import_module('..postgresql', package='dlairflow.test')
+
+    tf = p.__dict__['q3c_index']
+    test_operator = tf("login,password,host,schema", 'q3c_schema', 'q3c_table')
+    assert os.path.exists(str(temporary_airflow_home / 'dags' / 'sql' / 'dlairflow.postgresql.q3c_index.sql'))
+    assert test_operator.task_id == 'q3c_index'
+    assert test_operator.sql == 'sql/dlairflow.postgresql.q3c_index.sql'
+    env = Environment(loader=FileSystemLoader(searchpath=str(temporary_airflow_home / 'dags')),
+                      keep_trailing_newline=True)
+    tmpl = env.get_template(test_operator.sql)
+    expected_render = """--
+-- Created by dlairflow.postgresql.q3c_index().
+--
+CREATE INDEX q3c_table_q3c_ang2ipix ON q3c_schema.q3c_table (q3c_ang2ipix("ra", "dec")) WITH (fillfactor=100);
+CLUSTER q3c_table_q3c_ang2ipix ON q3c_schema.q3c_table;
+"""
+    assert tmpl.render(params=test_operator.params) == expected_render

--- a/dlairflow/test/test_postgresql.py
+++ b/dlairflow/test/test_postgresql.py
@@ -70,6 +70,7 @@ def test_pg_dump_schema(monkeypatch, temporary_airflow_home, task_function, dump
     else:
         assert test_operator.params['dump_dir'] == 'dump_dir'
 
+
 @pytest.mark.parametrize('overwrite', [(False, ), (True, )])
 def test_q3c_index(monkeypatch, temporary_airflow_home, overwrite):
     """Test the q3c_index function.
@@ -96,10 +97,68 @@ def test_q3c_index(monkeypatch, temporary_airflow_home, overwrite):
     tmpl = env.get_template(test_operator.sql)
     expected_render = """--
 -- Created by dlairflow.postgresql.q3c_index().
+-- Call q3c_index(..., overwrite=True) to replace this file.
 --
 CREATE INDEX q3c_table_q3c_ang2ipix
     ON q3c_schema.q3c_table (q3c_ang2ipix("ra", "dec"))
     WITH (fillfactor=100);
 CLUSTER q3c_table_q3c_ang2ipix ON q3c_schema.q3c_table;
+"""
+    assert tmpl.render(params=test_operator.params) == expected_render
+
+
+@pytest.mark.parametrize('overwrite', [(False, ), (True, )])
+def test_index_columns(monkeypatch, temporary_airflow_home, overwrite):
+    """Test the index_columns function.
+    """
+    #
+    # Import inside the function to avoid creating $HOME/airflow.
+    #
+    from airflow.hooks.base import BaseHook
+    from airflow.providers.postgres.operators.postgres import PostgresOperator
+
+    monkeypatch.setattr(BaseHook, "get_connection", mock_connection)
+
+    p = import_module('..postgresql', package='dlairflow.test')
+
+    tf = p.__dict__['index_columns']
+    test_operator = tf("login,password,host,schema", 'test_schema', 'test_table',
+                       columns=['ra', 'dec',
+                                ('id', 'survey', 'program'),
+                                12345,
+                                {'test_schema.uint64': 'specobjid'}],
+                       overwrite=overwrite)
+    assert isinstance(test_operator, PostgresOperator)
+    assert os.path.exists(str(temporary_airflow_home / 'dags' / 'sql' /
+                              'dlairflow.postgresql.index_columns.sql'))
+    assert test_operator.task_id == 'index_columns'
+    assert test_operator.sql == 'sql/dlairflow.postgresql.index_columns.sql'
+    env = Environment(loader=FileSystemLoader(searchpath=str(temporary_airflow_home / 'dags')),
+                      keep_trailing_newline=True)
+    tmpl = env.get_template(test_operator.sql)
+    expected_render = """--
+-- Created by dlairflow.postgresql.index_columns().
+-- Call index_columns(..., overwrite=True) to replace this file.
+--
+
+CREATE INDEX test_table_ra_idx
+    ON test_schema.test_table ("ra")
+    WITH (fillfactor=100);
+
+CREATE INDEX test_table_dec_idx
+    ON test_schema.test_table ("dec")
+    WITH (fillfactor=100);
+
+CREATE INDEX test_table_id_survey_program_idx
+    ON test_schema.test_table ("id", "survey", "program")
+    WITH (fillfactor=100);
+
+-- Unknown type: 12345.
+
+CREATE_INDEX test_table_test_schema_uint64_specobjid_idx
+    ON test_schema.test_table (test_schema.uint64(specobjid))
+    WITH (fillfactor=100);
+
+
 """
     assert tmpl.render(params=test_operator.params) == expected_render

--- a/dlairflow/test/test_postgresql.py
+++ b/dlairflow/test/test_postgresql.py
@@ -18,7 +18,7 @@ class MockConnection(object):
         return
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def temporary_airflow_home(tmp_path_factory):
     """Avoid creating ``${HOME}/airflow`` during tests.
     """

--- a/dlairflow/test/test_util.py
+++ b/dlairflow/test/test_util.py
@@ -26,4 +26,3 @@ def test_ensure_sql_no_home():
     """
     with pytest.raises(KeyError):
         foo = ensure_sql()
-

--- a/dlairflow/test/test_util.py
+++ b/dlairflow/test/test_util.py
@@ -3,6 +3,7 @@
 """Test dlairflow.util.
 """
 import os
+import pytest
 from ..util import user_scratch, ensure_sql
 from .test_postgresql import temporary_airflow_home
 
@@ -18,3 +19,11 @@ def test_ensure_sql(temporary_airflow_home):
     """
     assert ensure_sql() == str(temporary_airflow_home / 'dags' / 'sql')
     assert os.path.isdir(str(temporary_airflow_home / 'dags' / 'sql'))
+
+
+def test_ensure_sql_no_home():
+    """Test ensure_sql without AIRFLOW_HOME.
+    """
+    with pytest.raises(KeyError):
+        foo = ensure_sql()
+

--- a/dlairflow/test/test_util.py
+++ b/dlairflow/test/test_util.py
@@ -3,10 +3,18 @@
 """Test dlairflow.util.
 """
 import os
-from ..util import user_scratch
+from ..util import user_scratch, ensure_sql
+from .test_postgresql import temporary_airflow_home
 
 
 def test_user_scratch():
     """Test scratch dir.
     """
     assert user_scratch() == os.path.join('/data0', 'datalab', os.environ['USER'])
+
+
+def test_ensure_sql(temporary_airflow_home):
+    """Test SQL directory creation.
+    """
+    assert ensure_sql() == str(temporary_airflow_home / 'dags' / 'sql')
+    assert os.path.isdir(str(temporary_airflow_home / 'dags' / 'sql'))

--- a/dlairflow/util.py
+++ b/dlairflow/util.py
@@ -30,6 +30,11 @@ def ensure_sql():
     -------
     :class:`str`
         The full path to the directory.
+
+    Raises
+    ------
+    KeyError
+        If :envvar:`AIRFLOW_HOME` is not defined.
     """
     sql_dir = os.path.join(os.environ['AIRFLOW_HOME'], 'dags', 'sql')
     os.makedirs(sql_dir, exist_ok=True)

--- a/dlairflow/util.py
+++ b/dlairflow/util.py
@@ -21,3 +21,16 @@ def user_scratch():
         The name of the directory.
     """
     return os.path.join('/data0', 'datalab', os.environ['USER'])
+
+
+def ensure_sql():
+    """Ensure that ``${AIRFLOW_HOME}/dags/sql`` exists.
+
+    Returns
+    -------
+    :class:`str`
+        The full path to the directory.
+    """
+    sql_dir = os.path.join(os.environ['AIRFLOW_HOME'], 'dags', 'sql')
+    os.makedirs(sql_dir, exist_ok=True)
+    return sql_dir


### PR DESCRIPTION
This PR adds support for some standardizable SQL tasks:

* Create indexes on a column or a group of columns.
* Create q3c index on columns corresponding to RA, Dec.
* Create a primary key on a table that doesn't already have one, which is a common occurrence when ingesting a new table.

There are other possible standardizable SQL tasks of course, *e.g.*:

* Setting permissions.
* Creating a schema.
* Truncating a table to reload it.

The intention of this PR is to create a framework for adding these additional tasks in later PRs.

@jacquesalice if you have suggestions about how to modify the index creation for tablespaces, please comment. I've seen the documentation on Confluence, so I know the syntax, but we might need to compile a list of available tablespaces and determine, do the tablespaces have the same naming convention on all servers?