### PR TITLE
Add tablespace support to existing functions

### DIFF
--- a/dlairflow/postgresql.py
+++ b/dlairflow/postgresql.py
@@ -146,7 +146,7 @@ def q3c_index(connection, schema, table, ra='ra', dec='dec',
 --
 CREATE INDEX {{ params.table }}_q3c_ang2ipix
     ON {{ params.schema }}.{{ params.table }} (q3c_ang2ipix("{{ params.ra }}", "{{ params.dec }}"))
-    WITH (fillfactor=100){%- if params.tablespace -%} TABLESPACE {{ params.tablespace }}{%- endif -%};
+    WITH (fillfactor=100){%- if params.tablespace %} TABLESPACE {{ params.tablespace }}{%- endif -%};
 CLUSTER {{ params.table }}_q3c_ang2ipix ON {{ params.schema }}.{{ params.table }};
 """
         with open(sql_file, 'w') as s:

--- a/dlairflow/postgresql.py
+++ b/dlairflow/postgresql.py
@@ -272,9 +272,11 @@ def primary_key(connection, schema, primary_keys, overwrite=False):
 --
 {% for table, columns in params.primary_keys.items() %}
 {% if columns is string -%}
-ALTER TABLE {{ params.schema }}.{{ table }} ADD PRIMARY KEY ("{{ columns }}");
+ALTER TABLE {{ params.schema }}.{{ table }} ADD PRIMARY KEY ("{{ columns }}")
+    WITH (fillfactor=100);
 {% elif columns is sequence -%}
-ALTER TABLE {{ params.schema }}.{{ table }} ADD PRIMARY KEY ("{{ columns|join('", "') }}");
+ALTER TABLE {{ params.schema }}.{{ table }} ADD PRIMARY KEY ("{{ columns|join('", "') }}")
+    WITH (fillfactor=100);
 {% else -%}
 -- Unknown type: {{ columns }}.
 {% endif -%}

--- a/dlairflow/postgresql.py
+++ b/dlairflow/postgresql.py
@@ -231,7 +231,7 @@ CREATE INDEX {{ params.table }}_{{ col|join("_") }}_idx
                                     task_id="index_columns")
 
 
-def primary_key(connection, schema, primary_keys, overwrite=False):
+def primary_key(connection, schema, primary_keys, tablespace=None, overwrite=False):
     """Create a primary key on one or more tables in `schema`.
 
     Parameters
@@ -243,6 +243,8 @@ def primary_key(connection, schema, primary_keys, overwrite=False):
     primary_keys : :class:`dict`
         A dictionary containing the of the table in `schema` mapped to the
         primary key column(s). See below for details.
+    tablespace : :class:`str`, optional
+        Create the indexes in a specific tablespace if set.
     overwrite : :class:`bool`, optional
         If ``True`` replace any existing SQL template file.
 
@@ -273,10 +275,10 @@ def primary_key(connection, schema, primary_keys, overwrite=False):
 {% for table, columns in params.primary_keys.items() %}
 {% if columns is string -%}
 ALTER TABLE {{ params.schema }}.{{ table }} ADD PRIMARY KEY ("{{ columns }}")
-    WITH (fillfactor=100);
+    WITH (fillfactor=100){%- if params.tablespace %} TABLESPACE {{ params.tablespace }}{%- endif -%};
 {% elif columns is sequence -%}
 ALTER TABLE {{ params.schema }}.{{ table }} ADD PRIMARY KEY ("{{ columns|join('", "') }}")
-    WITH (fillfactor=100);
+    WITH (fillfactor=100){%- if params.tablespace %} TABLESPACE {{ params.tablespace }}{%- endif -%};
 {% else -%}
 -- Unknown type: {{ columns }}.
 {% endif -%}

--- a/dlairflow/postgresql.py
+++ b/dlairflow/postgresql.py
@@ -287,7 +287,9 @@ ALTER TABLE {{ params.schema }}.{{ table }} ADD PRIMARY KEY ("{{ columns|join('"
         with open(sql_file, 'w') as s:
             s.write(sql_data)
     return _PostgresOperatorWrapper(sql=f"sql/{sql_basename}",
-                                    params={'schema': schema, 'primary_keys': primary_keys},
+                                    params={'schema': schema,
+                                            'primary_keys': primary_keys,
+                                            'tablespace': tablespace},
                                     conn_id=connection,
                                     task_id="primary_key")
 

--- a/dlairflow/postgresql.py
+++ b/dlairflow/postgresql.py
@@ -275,10 +275,10 @@ def primary_key(connection, schema, primary_keys, tablespace=None, overwrite=Fal
 {% for table, columns in params.primary_keys.items() %}
 {% if columns is string -%}
 ALTER TABLE {{ params.schema }}.{{ table }} ADD PRIMARY KEY ("{{ columns }}")
-    WITH (fillfactor=100){%- if params.tablespace %} TABLESPACE {{ params.tablespace }}{%- endif -%};
+    WITH (fillfactor=100){%- if params.tablespace %} USING INDEX TABLESPACE {{ params.tablespace }}{%- endif -%};
 {% elif columns is sequence -%}
 ALTER TABLE {{ params.schema }}.{{ table }} ADD PRIMARY KEY ("{{ columns|join('", "') }}")
-    WITH (fillfactor=100){%- if params.tablespace %} TABLESPACE {{ params.tablespace }}{%- endif -%};
+    WITH (fillfactor=100){%- if params.tablespace %} USING INDEX TABLESPACE {{ params.tablespace }}{%- endif -%};
 {% else -%}
 -- Unknown type: {{ columns }}.
 {% endif -%}

--- a/dlairflow/postgresql.py
+++ b/dlairflow/postgresql.py
@@ -146,7 +146,7 @@ def q3c_index(connection, schema, table, ra='ra', dec='dec',
 --
 CREATE INDEX {{ params.table }}_q3c_ang2ipix
     ON {{ params.schema }}.{{ params.table }} (q3c_ang2ipix("{{ params.ra }}", "{{ params.dec }}"))
-    WITH (fillfactor=100){% if params.tablespace -%}TABLESPACE {{ params.tablespace }}{%- endif -%};
+    WITH (fillfactor=100){%- if params.tablespace -%} TABLESPACE {{ params.tablespace }}{%- endif -%};
 CLUSTER {{ params.table }}_q3c_ang2ipix ON {{ params.schema }}.{{ params.table }};
 """
         with open(sql_file, 'w') as s:

--- a/dlairflow/postgresql.py
+++ b/dlairflow/postgresql.py
@@ -146,7 +146,7 @@ def q3c_index(connection, schema, table, ra='ra', dec='dec',
 --
 CREATE INDEX {{ params.table }}_q3c_ang2ipix
     ON {{ params.schema }}.{{ params.table }} (q3c_ang2ipix("{{ params.ra }}", "{{ params.dec }}"))
-    WITH (fillfactor=100){%- if params.tablespace -%}TABLESPACE {{ params.tablespace }}{%- endif -%};
+    WITH (fillfactor=100){% if params.tablespace -%}TABLESPACE {{ params.tablespace }}{%- endif -%};
 CLUSTER {{ params.table }}_q3c_ang2ipix ON {{ params.schema }}.{{ params.table }};
 """
         with open(sql_file, 'w') as s:

--- a/dlairflow/test/test_postgresql.py
+++ b/dlairflow/test/test_postgresql.py
@@ -273,10 +273,10 @@ def test_primary_key(monkeypatch, temporary_airflow_home, overwrite, tablespace)
 --
 
 ALTER TABLE test_schema.table1 ADD PRIMARY KEY ("column1")
-    WITH (fillfactor=100) TABLESPACE {tablespace};
+    WITH (fillfactor=100) USING INDEX TABLESPACE {tablespace};
 
 ALTER TABLE test_schema.table2 ADD PRIMARY KEY ("column1", "column2")
-    WITH (fillfactor=100) TABLESPACE {tablespace};
+    WITH (fillfactor=100) USING INDEX TABLESPACE {tablespace};
 
 -- Unknown type: 12345.
 

--- a/dlairflow/test/test_postgresql.py
+++ b/dlairflow/test/test_postgresql.py
@@ -257,7 +257,7 @@ def test_primary_key(monkeypatch, temporary_airflow_home, overwrite, tablespace)
                        {"table1": "column1",
                         "table2": ("column1", "column2"),
                         "table3": 12345},
-                       overwrite=overwrite)
+                       tablespace=tablespace, overwrite=overwrite)
     assert isinstance(test_operator, PostgresOperator)
     assert os.path.exists(str(temporary_airflow_home / 'dags' / 'sql' /
                               'dlairflow.postgresql.primary_key.sql'))

--- a/dlairflow/test/test_postgresql.py
+++ b/dlairflow/test/test_postgresql.py
@@ -270,9 +270,11 @@ def test_primary_key(monkeypatch, temporary_airflow_home, overwrite):
 -- Call primary_key(..., overwrite=True) to replace this file.
 --
 
-ALTER TABLE test_schema.table1 ADD PRIMARY KEY ("column1");
+ALTER TABLE test_schema.table1 ADD PRIMARY KEY ("column1")
+    WITH (fillfactor=100);
 
-ALTER TABLE test_schema.table2 ADD PRIMARY KEY ("column1", "column2");
+ALTER TABLE test_schema.table2 ADD PRIMARY KEY ("column1", "column2")
+    WITH (fillfactor=100);
 
 -- Unknown type: 12345.
 

--- a/dlairflow/test/test_postgresql.py
+++ b/dlairflow/test/test_postgresql.py
@@ -95,7 +95,8 @@ def test_pg_dump_schema(monkeypatch, temporary_airflow_home, task_function, dump
         assert test_operator.params['dump_dir'] == 'dump_dir'
 
 
-@pytest.mark.parametrize('overwrite,tablespace', [(False, None), (True, None), (False, 'data3'), (True, 'data3')])
+@pytest.mark.parametrize('overwrite,tablespace', [(False, None), (True, None),
+                                                  (False, 'data3'), (True, 'data3')])
 def test_q3c_index(monkeypatch, temporary_airflow_home, overwrite, tablespace):
     """Test the q3c_index function.
     """

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,7 +5,9 @@ dlairflow Change Log
 0.1.5 (unreleased)
 ------------------
 
-* No changes yet.
+* Support ``TABLESPACE`` when creating indexes (PR `#11`_).
+
+.. _`#11`: https://github.com/astro-datalab/dlairflow/pull/11
 
 0.1.4 (2025-07-24)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,5 +100,5 @@ exclude_lines =
 #
 # In addition this is not ignored, but modified by max-line-length:
 # - E501 line too long (L > max-line-length characters)
-max-line-length = 110
+max-line-length = 115
 ignore =


### PR DESCRIPTION
This PR closes #6.

With this PR, all existing functions that *can* support a tablespace option do. In the future, the development plan should simply be to continue to support tablespace functionality on operations that involve *e.g.* `CREATE TABLE`.

I've done some initial tests with the `dlairflow_test` DAG. Please take a look at that to see how it works in practice.