### PR TITLE
Add truncate table function

### DIFF
--- a/dlairflow/postgresql.py
+++ b/dlairflow/postgresql.py
@@ -340,7 +340,9 @@ def truncate_table(connection, schema, table, restart=False, cascade=False,
 -- Created by dlairflow.postgresql.truncate_table().
 -- Call truncate_table(..., overwrite=True) to replace this file.
 --
-TRUNCATE TABLE {% for table in params.tables -%}{{ params.schema }}.{{ table }}{{ '' if loop.last else ', ' }}{%- endfor %}
+TRUNCATE TABLE {% for table in params.tables -%}
+    {{ params.schema }}.{{ table }}{{ '' if loop.last else ', ' }}
+    {%- endfor %}
     {% if params.restart -%}RESTART{%- else -%}CONTINUE{%- endif %} IDENTITY
     {% if params.cascade -%}CASCADE{%- else -%}RESTRICT{%- endif %};
 """

--- a/dlairflow/postgresql.py
+++ b/dlairflow/postgresql.py
@@ -294,6 +294,67 @@ ALTER TABLE {{ params.schema }}.{{ table }} ADD PRIMARY KEY ("{{ columns|join('"
                                     task_id="primary_key")
 
 
+def truncate_table(connection, schema, table, restart=False, cascade=False,
+                   overwrite=False):
+    """Run ``TRUNCATE TABLE`` on one or more tables in `schema`.
+
+    Parameters
+    ----------
+    connection : :class:`str`
+        An Airflow database connection string.
+    schema : :class:`str`
+        The name of the database schema.
+    table : :class:`str` or :class:`list`
+        The table(s) to operate on.
+    restart : :class:`bool`, optional
+        If ``True``, any sequences associated with columns in the table(s) will
+        be reset. The default is not to reset such sequences.
+    cascade : :class:`bool`, optional
+        If ``True``, the ``TRUNCATE`` command will also truncate tables connected
+        by foreign key relationships. *This is extrememly dangerous!*
+    overwrite : :class:`bool`, optional
+        If ``True``, replace any existing SQL template file.
+
+    Returns
+    -------
+    :class:`~airflow.providers.postgres.operators.postgres.PostgresOperator`
+        A task to run a ``TRUNCATE TABLE`` command.
+
+    Raises
+    ------
+    ValueError
+        If `table` is not a string or list-like object.
+
+    """
+    if isinstance(table, str):
+        tables = [table]
+    elif isinstance(table, (list, tuple, set, frozenset)):
+        tables = table
+    else:
+        raise ValueError("Unknown type for table, must be string or list-like!")
+    sql_dir = ensure_sql()
+    sql_basename = "dlairflow.postgresql.truncate_table.sql"
+    sql_file = os.path.join(sql_dir, sql_basename)
+    if overwrite or not os.path.exists(sql_file):
+        sql_data = """--
+-- Created by dlairflow.postgresql.truncate_table().
+-- Call truncate_table(..., overwrite=True) to replace this file.
+--
+TRUNCATE TABLE {% for table in params.tables -%}{{ params.schema }}.{{ table }}{{ '' if loop.last else ', ' }}{%- endfor %}
+    {% if params.restart -%}RESTART{%- else -%}CONTINUE{%- endif %} IDENTITY
+    {% if params.cascade -%}CASCADE{%- else -%}RESTRICT{%- endif %};
+"""
+        with open(sql_file, 'w') as s:
+            s.write(sql_data)
+    return _PostgresOperatorWrapper(sql=f"sql/{sql_basename}",
+                                    params={'schema': schema,
+                                            'tables': tables,
+                                            'restart': restart,
+                                            'cascade': cascade},
+                                    conn_id=connection,
+                                    task_id="truncate_table")
+
+
 def vacuum_analyze(connection, schema, table, full=False, overwrite=False):
     """Run ``VACUUM`` and ``ANALYZE`` on one or more tables in `schema`.
 

--- a/dlairflow/test/test_postgresql.py
+++ b/dlairflow/test/test_postgresql.py
@@ -112,21 +112,22 @@ def test_q3c_index(monkeypatch, temporary_airflow_home, overwrite, tablespace):
     monkeypatch.setattr(BaseHook, "get_connection", mock_connection)
 
     p = import_module('..postgresql', package='dlairflow.test')
-
-    tf = p.__dict__['q3c_index']
+    function_name = 'q3c_index'
+    tf = p.__dict__[function_name]
     test_operator = tf("login,password,host,schema", 'q3c_schema', 'q3c_table',
                        tablespace=tablespace, overwrite=overwrite)
     assert isinstance(test_operator, PostgresOperator)
-    assert os.path.exists(str(temporary_airflow_home / 'dags' / 'sql' / 'dlairflow.postgresql.q3c_index.sql'))
-    assert test_operator.task_id == 'q3c_index'
-    assert test_operator.sql == 'sql/dlairflow.postgresql.q3c_index.sql'
+    assert os.path.exists(str(temporary_airflow_home / 'dags' / 'sql' /
+                              f'dlairflow.postgresql.{function_name}.sql'))
+    assert test_operator.task_id == function_name
+    assert test_operator.sql == f'sql/dlairflow.postgresql.{function_name}.sql'
     env = Environment(loader=FileSystemLoader(searchpath=str(temporary_airflow_home / 'dags')),
                       keep_trailing_newline=True)
     tmpl = env.get_template(test_operator.sql)
     if tablespace:
         expected_render = f"""--
--- Created by dlairflow.postgresql.q3c_index().
--- Call q3c_index(..., overwrite=True) to replace this file.
+-- Created by dlairflow.postgresql.{function_name}().
+-- Call {function_name}(..., overwrite=True) to replace this file.
 --
 CREATE INDEX q3c_table_q3c_ang2ipix
     ON q3c_schema.q3c_table (q3c_ang2ipix("ra", "dec"))
@@ -134,9 +135,9 @@ CREATE INDEX q3c_table_q3c_ang2ipix
 CLUSTER q3c_table_q3c_ang2ipix ON q3c_schema.q3c_table;
 """
     else:
-        expected_render = """--
--- Created by dlairflow.postgresql.q3c_index().
--- Call q3c_index(..., overwrite=True) to replace this file.
+        expected_render = f"""--
+-- Created by dlairflow.postgresql.{function_name}().
+-- Call {function_name}(..., overwrite=True) to replace this file.
 --
 CREATE INDEX q3c_table_q3c_ang2ipix
     ON q3c_schema.q3c_table (q3c_ang2ipix("ra", "dec"))
@@ -163,8 +164,8 @@ def test_index_columns(monkeypatch, temporary_airflow_home, overwrite, tablespac
     monkeypatch.setattr(BaseHook, "get_connection", mock_connection)
 
     p = import_module('..postgresql', package='dlairflow.test')
-
-    tf = p.__dict__['index_columns']
+    function_name = 'index_columns'
+    tf = p.__dict__[function_name]
     test_operator = tf("login,password,host,schema", 'test_schema', 'test_table',
                        columns=['ra', 'dec',
                                 ('id', 'survey', 'program'),
@@ -173,16 +174,16 @@ def test_index_columns(monkeypatch, temporary_airflow_home, overwrite, tablespac
                        tablespace=tablespace, overwrite=overwrite)
     assert isinstance(test_operator, PostgresOperator)
     assert os.path.exists(str(temporary_airflow_home / 'dags' / 'sql' /
-                              'dlairflow.postgresql.index_columns.sql'))
-    assert test_operator.task_id == 'index_columns'
-    assert test_operator.sql == 'sql/dlairflow.postgresql.index_columns.sql'
+                              f'dlairflow.postgresql.{function_name}.sql'))
+    assert test_operator.task_id == function_name
+    assert test_operator.sql == f'sql/dlairflow.postgresql.{function_name}.sql'
     env = Environment(loader=FileSystemLoader(searchpath=str(temporary_airflow_home / 'dags')),
                       keep_trailing_newline=True)
     tmpl = env.get_template(test_operator.sql)
     if tablespace:
         expected_render = f"""--
--- Created by dlairflow.postgresql.index_columns().
--- Call index_columns(..., overwrite=True) to replace this file.
+-- Created by dlairflow.postgresql.{function_name}().
+-- Call {function_name}(..., overwrite=True) to replace this file.
 --
 
 CREATE INDEX test_table_ra_idx
@@ -206,9 +207,9 @@ CREATE_INDEX test_table_test_schema_uint64_specobjid_idx
 
 """
     else:
-        expected_render = """--
--- Created by dlairflow.postgresql.index_columns().
--- Call index_columns(..., overwrite=True) to replace this file.
+        expected_render = f"""--
+-- Created by dlairflow.postgresql.{function_name}().
+-- Call {function_name}(..., overwrite=True) to replace this file.
 --
 
 CREATE INDEX test_table_ra_idx
@@ -251,8 +252,8 @@ def test_primary_key(monkeypatch, temporary_airflow_home, overwrite, tablespace)
     monkeypatch.setattr(BaseHook, "get_connection", mock_connection)
 
     p = import_module('..postgresql', package='dlairflow.test')
-
-    tf = p.__dict__['primary_key']
+    function_name = 'primary_key'
+    tf = p.__dict__[function_name]
     test_operator = tf("login,password,host,schema", 'test_schema',
                        {"table1": "column1",
                         "table2": ("column1", "column2"),
@@ -260,16 +261,16 @@ def test_primary_key(monkeypatch, temporary_airflow_home, overwrite, tablespace)
                        tablespace=tablespace, overwrite=overwrite)
     assert isinstance(test_operator, PostgresOperator)
     assert os.path.exists(str(temporary_airflow_home / 'dags' / 'sql' /
-                              'dlairflow.postgresql.primary_key.sql'))
-    assert test_operator.task_id == 'primary_key'
-    assert test_operator.sql == 'sql/dlairflow.postgresql.primary_key.sql'
+                              f'dlairflow.postgresql.{function_name}.sql'))
+    assert test_operator.task_id == function_name
+    assert test_operator.sql == f'sql/dlairflow.postgresql.{function_name}.sql'
     env = Environment(loader=FileSystemLoader(searchpath=str(temporary_airflow_home / 'dags')),
                       keep_trailing_newline=True)
     tmpl = env.get_template(test_operator.sql)
     if tablespace:
         expected_render = f"""--
--- Created by dlairflow.postgresql.primary_key().
--- Call primary_key(..., overwrite=True) to replace this file.
+-- Created by dlairflow.postgresql.{function_name}().
+-- Call {function_name}(..., overwrite=True) to replace this file.
 --
 
 ALTER TABLE test_schema.table1 ADD PRIMARY KEY ("column1")
@@ -282,9 +283,9 @@ ALTER TABLE test_schema.table2 ADD PRIMARY KEY ("column1", "column2")
 
 """
     else:
-        expected_render = """--
--- Created by dlairflow.postgresql.primary_key().
--- Call primary_key(..., overwrite=True) to replace this file.
+        expected_render = f"""--
+-- Created by dlairflow.postgresql.{function_name}().
+-- Call {function_name}(..., overwrite=True) to replace this file.
 --
 
 ALTER TABLE test_schema.table1 ADD PRIMARY KEY ("column1")

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,9 +5,11 @@ dlairflow Change Log
 0.1.5 (unreleased)
 ------------------
 
+* Add function to support ``TRUNCATE TABLE`` tasks (PR `#12`_).
 * Support ``TABLESPACE`` when creating indexes (PR `#11`_).
 
 .. _`#11`: https://github.com/astro-datalab/dlairflow/pull/11
+.. _`#12`: https://github.com/astro-datalab/dlairflow/pull/12
 
 0.1.4 (2025-07-24)
 ------------------


### PR DESCRIPTION
This PR adds a `truncate_table()` function that returns a task implementing `TRUNCATE TABLE` and the optional qualifiers in the PostgreSQL version.

There are also some minor changes to the test infrastructure to make the *test* code more reusable.